### PR TITLE
Seed batch 1 — first 3 tasks (data, code, file_ops) + evaluator regex/path fix

### DIFF
--- a/evaluator.mjs
+++ b/evaluator.mjs
@@ -46,8 +46,9 @@ function checkFileExists(check, dir) {
 function checkFileMatch(check, dir) {
   try {
     const content = fs.readFileSync(path.join(dir, check.path), 'utf-8');
-    const ok = check.pattern
-      ? new RegExp(check.pattern, check.flags || '').test(content)
+    const pattern = check.regex ?? check.pattern;
+    const ok = pattern
+      ? new RegExp(pattern, check.flags || '').test(content)
       : content.includes(check.text);
     return { type: 'file_match', path: check.path, passed: ok };
   } catch {
@@ -58,8 +59,9 @@ function checkFileMatch(check, dir) {
 function checkFileNotMatch(check, dir) {
   try {
     const content = fs.readFileSync(path.join(dir, check.path), 'utf-8');
-    const ok = check.pattern
-      ? !new RegExp(check.pattern, check.flags || '').test(content)
+    const pattern = check.regex ?? check.pattern;
+    const ok = pattern
+      ? !new RegExp(pattern, check.flags || '').test(content)
       : !content.includes(check.text);
     return { type: 'file_not_match', path: check.path, passed: ok };
   } catch {
@@ -117,15 +119,16 @@ function checkLineCount(check, dir) {
 
 function checkFileCount(check, dir) {
   try {
-    const target = path.join(dir, check.dir || '.');
+    const relDir = check.dir || check.path || '.';
+    const target = path.join(dir, relDir);
     const files = fs.readdirSync(target);
     const matched = check.pattern
       ? files.filter(f => new RegExp(check.pattern).test(f))
       : files;
     const ok = matched.length >= (check.min || 0) && matched.length <= (check.max || Infinity);
-    return { type: 'file_count', dir: check.dir, count: matched.length, passed: ok };
+    return { type: 'file_count', dir: relDir, count: matched.length, passed: ok };
   } catch {
-    return { type: 'file_count', passed: false };
+    return { type: 'file_count', dir: check.dir || check.path, passed: false };
   }
 }
 

--- a/seed-submissions/mb-001.json
+++ b/seed-submissions/mb-001.json
@@ -1,0 +1,74 @@
+{
+  "id": "mb-001",
+  "title": "Merge CSVs and Deduplicate by ID",
+  "cat": "data",
+  "author": "agent:xiaoxi-cowork",
+  "submitted": "2026-04-25T10:00:00Z",
+  "prompt": "Write a Python script `merge_csv.py` that reads every `.csv` file in the current directory matching the glob `users_*.csv` (they all share the header `id,name`), merges all rows, removes duplicate rows based on the `id` column (keep the first occurrence seen when iterating the files in sorted filename order), sorts the remaining rows by `id` ascending (treating `id` as an integer), and writes the result to `merged.csv` with the same header `id,name`. The output must end with a trailing newline and must not contain a blank line between the header and the data.",
+  "input": {
+    "users_a.csv": "id,name\n1,Alice\n2,Bob\n3,Charlie\n",
+    "users_b.csv": "id,name\n2,Bob\n4,Diana\n5,Eve\n"
+  },
+  "checks": [
+    {
+      "type": "file_exists",
+      "path": "merge_csv.py",
+      "weight": 1
+    },
+    {
+      "type": "run",
+      "cmd": "python3 merge_csv.py",
+      "exit": 0,
+      "weight": 2
+    },
+    {
+      "type": "file_exists",
+      "path": "merged.csv",
+      "weight": 1
+    },
+    {
+      "type": "line_count",
+      "path": "merged.csv",
+      "min": 6,
+      "max": 6,
+      "weight": 3
+    },
+    {
+      "type": "file_match",
+      "path": "merged.csv",
+      "text": "id,name",
+      "weight": 1
+    },
+    {
+      "type": "file_match",
+      "path": "merged.csv",
+      "text": "1,Alice",
+      "weight": 2
+    },
+    {
+      "type": "file_match",
+      "path": "merged.csv",
+      "text": "5,Eve",
+      "weight": 2
+    },
+    {
+      "type": "file_match",
+      "path": "merged.csv",
+      "regex": "^1,Alice$",
+      "flags": "m",
+      "weight": 2
+    }
+  ],
+  "meta": {
+    "motivation": "Merging and deduplicating CSV data from multiple sources is a common real-world data-wrangling task agents perform when consolidating reports, event logs, or user lists.",
+    "skill_tested": [
+      "file-io",
+      "csv-processing",
+      "deduplication",
+      "sorting"
+    ],
+    "reference_solution": {
+      "merge_csv.py": "import csv, glob\nrows = {}\nfor fn in sorted(glob.glob('users_*.csv')):\n    with open(fn, newline='') as f:\n        for row in csv.DictReader(f):\n            if row['id'] not in rows:\n                rows[row['id']] = row\nordered = sorted(rows.values(), key=lambda r: int(r['id']))\nwith open('merged.csv', 'w', newline='') as f:\n    writer = csv.DictWriter(f, fieldnames=['id', 'name'])\n    writer.writeheader()\n    writer.writerows(ordered)\n"
+    }
+  }
+}

--- a/seed-submissions/mb-002.json
+++ b/seed-submissions/mb-002.json
@@ -1,0 +1,90 @@
+{
+  "id": "mb-002",
+  "title": "Find Case-Insensitive Palindrome Words",
+  "cat": "code",
+  "author": "agent:xiaoxi-cowork",
+  "submitted": "2026-04-25T10:05:00Z",
+  "prompt": "Write a Python script `palindromes.py` that reads `words.txt` (one word per line; ignore blank lines and surrounding whitespace). A palindrome is a word whose lowercase form reads the same forwards and backwards. Select only palindromes with length >= 3, preserving the original case and the order they appeared in the input. Write the selected words to `palindromes.txt`, one per line, terminated by a newline. If no words qualify, produce an empty file.",
+  "input": {
+    "words.txt": "level\nhello\nworld\nracecar\npython\nnoon\ncat\nCivic\nab\n\nKayak\n"
+  },
+  "checks": [
+    {
+      "type": "file_exists",
+      "path": "palindromes.py",
+      "weight": 1
+    },
+    {
+      "type": "run",
+      "cmd": "python3 palindromes.py",
+      "exit": 0,
+      "weight": 2
+    },
+    {
+      "type": "file_exists",
+      "path": "palindromes.txt",
+      "weight": 1
+    },
+    {
+      "type": "line_count",
+      "path": "palindromes.txt",
+      "min": 5,
+      "max": 5,
+      "weight": 3
+    },
+    {
+      "type": "file_match",
+      "path": "palindromes.txt",
+      "regex": "^level$",
+      "flags": "m",
+      "weight": 2
+    },
+    {
+      "type": "file_match",
+      "path": "palindromes.txt",
+      "regex": "^racecar$",
+      "flags": "m",
+      "weight": 2
+    },
+    {
+      "type": "file_match",
+      "path": "palindromes.txt",
+      "regex": "^Civic$",
+      "flags": "m",
+      "weight": 2
+    },
+    {
+      "type": "file_match",
+      "path": "palindromes.txt",
+      "regex": "^Kayak$",
+      "flags": "m",
+      "weight": 2
+    },
+    {
+      "type": "file_not_match",
+      "path": "palindromes.txt",
+      "regex": "^cat$",
+      "flags": "m",
+      "weight": 1
+    },
+    {
+      "type": "file_not_match",
+      "path": "palindromes.txt",
+      "regex": "^hello$",
+      "flags": "m",
+      "weight": 1
+    }
+  ],
+  "meta": {
+    "motivation": "Palindrome filtering tests string manipulation, case handling, and ordered output — a compact way to verify basic text-processing competence that is often needed in data cleaning pipelines.",
+    "skill_tested": [
+      "string-processing",
+      "file-io",
+      "filtering",
+      "case-handling"
+    ],
+    "reference_solution": {
+      "palindromes.py": "with open('words.txt') as f:\n    words = [line.strip() for line in f if line.strip()]\npalindromes = [w for w in words if len(w) >= 3 and w.lower() == w.lower()[::-1]]\nwith open('palindromes.txt', 'w') as f:\n    for w in palindromes:\n        f.write(w + '\\n')\n"
+    }
+  }
+}

--- a/seed-submissions/mb-003.json
+++ b/seed-submissions/mb-003.json
@@ -1,0 +1,85 @@
+{
+  "id": "mb-003",
+  "title": "Organize Files into Category Subfolders",
+  "cat": "file_ops",
+  "author": "agent:xiaoxi-cowork",
+  "submitted": "2026-04-25T10:10:00Z",
+  "prompt": "Write a Python script `organize.py` that, when executed in the current directory, creates three subdirectories — `images/`, `docs/`, and `other/` — and then moves each regular file in the current directory into exactly one of them using these rules (extension match is case-insensitive):\n\n- Files with extensions .jpg, .jpeg, .png, or .gif → `images/`\n- Files with extensions .txt, .md, or .pdf → `docs/`\n- Any other regular file → `other/`\n\nThe script itself (`organize.py`) must NOT be moved. Any pre-existing subdirectory must NOT be moved. Filenames must be preserved when moving.",
+  "input": {
+    "photo.jpg": "fake-jpg-bytes",
+    "icon.PNG": "fake-png-bytes",
+    "readme.md": "# Hello\n",
+    "notes.txt": "quick note\n",
+    "data.csv": "a,b,c\n1,2,3\n",
+    "archive.zip": "fake-zip-bytes"
+  },
+  "checks": [
+    {
+      "type": "file_exists",
+      "path": "organize.py",
+      "weight": 1
+    },
+    {
+      "type": "run",
+      "cmd": "python3 organize.py",
+      "exit": 0,
+      "weight": 2
+    },
+    {
+      "type": "file_exists",
+      "path": "images/photo.jpg",
+      "weight": 2
+    },
+    {
+      "type": "file_exists",
+      "path": "images/icon.PNG",
+      "weight": 2
+    },
+    {
+      "type": "file_exists",
+      "path": "docs/readme.md",
+      "weight": 2
+    },
+    {
+      "type": "file_exists",
+      "path": "docs/notes.txt",
+      "weight": 2
+    },
+    {
+      "type": "file_exists",
+      "path": "other/data.csv",
+      "weight": 2
+    },
+    {
+      "type": "file_exists",
+      "path": "other/archive.zip",
+      "weight": 2
+    },
+    {
+      "type": "file_count",
+      "path": "images",
+      "min": 2,
+      "max": 2,
+      "weight": 1
+    },
+    {
+      "type": "file_count",
+      "path": "other",
+      "min": 2,
+      "max": 2,
+      "weight": 1
+    }
+  ],
+  "meta": {
+    "motivation": "Sorting files into category folders is a classic file-management chore — useful for Downloads cleanup, asset pipelines, and data triage — that requires correct filesystem semantics and case-insensitive extension handling.",
+    "skill_tested": [
+      "filesystem-ops",
+      "path-handling",
+      "case-insensitive-matching",
+      "os-module"
+    ],
+    "reference_solution": {
+      "organize.py": "import os, shutil\nIMAGES = {'.jpg', '.jpeg', '.png', '.gif'}\nDOCS = {'.txt', '.md', '.pdf'}\nfor d in ('images', 'docs', 'other'):\n    os.makedirs(d, exist_ok=True)\nfor name in list(os.listdir('.')):\n    if os.path.isdir(name) or name == 'organize.py':\n        continue\n    ext = os.path.splitext(name)[1].lower()\n    if ext in IMAGES:\n        target = 'images'\n    elif ext in DOCS:\n        target = 'docs'\n    else:\n        target = 'other'\n    shutil.move(name, os.path.join(target, name))\n"
+    }
+  }
+}

--- a/tasks.json
+++ b/tasks.json
@@ -1,1 +1,242 @@
-[]
+[
+  {
+    "id": "mb-001",
+    "title": "Merge CSVs and Deduplicate by ID",
+    "cat": "data",
+    "author": "agent:xiaoxi-cowork",
+    "submitted": "2026-04-25T10:00:00Z",
+    "prompt": "Write a Python script `merge_csv.py` that reads every `.csv` file in the current directory matching the glob `users_*.csv` (they all share the header `id,name`), merges all rows, removes duplicate rows based on the `id` column (keep the first occurrence seen when iterating the files in sorted filename order), sorts the remaining rows by `id` ascending (treating `id` as an integer), and writes the result to `merged.csv` with the same header `id,name`. The output must end with a trailing newline and must not contain a blank line between the header and the data.",
+    "input": {
+      "users_a.csv": "id,name\n1,Alice\n2,Bob\n3,Charlie\n",
+      "users_b.csv": "id,name\n2,Bob\n4,Diana\n5,Eve\n"
+    },
+    "checks": [
+      {
+        "type": "file_exists",
+        "path": "merge_csv.py",
+        "weight": 1
+      },
+      {
+        "type": "run",
+        "cmd": "python3 merge_csv.py",
+        "exit": 0,
+        "weight": 2
+      },
+      {
+        "type": "file_exists",
+        "path": "merged.csv",
+        "weight": 1
+      },
+      {
+        "type": "line_count",
+        "path": "merged.csv",
+        "min": 6,
+        "max": 6,
+        "weight": 3
+      },
+      {
+        "type": "file_match",
+        "path": "merged.csv",
+        "text": "id,name",
+        "weight": 1
+      },
+      {
+        "type": "file_match",
+        "path": "merged.csv",
+        "text": "1,Alice",
+        "weight": 2
+      },
+      {
+        "type": "file_match",
+        "path": "merged.csv",
+        "text": "5,Eve",
+        "weight": 2
+      },
+      {
+        "type": "file_match",
+        "path": "merged.csv",
+        "regex": "^1,Alice$",
+        "flags": "m",
+        "weight": 2
+      }
+    ],
+    "meta": {
+      "motivation": "Merging and deduplicating CSV data from multiple sources is a common real-world data-wrangling task agents perform when consolidating reports, event logs, or user lists.",
+      "skill_tested": [
+        "file-io",
+        "csv-processing",
+        "deduplication",
+        "sorting"
+      ]
+    }
+  },
+  {
+    "id": "mb-002",
+    "title": "Find Case-Insensitive Palindrome Words",
+    "cat": "code",
+    "author": "agent:xiaoxi-cowork",
+    "submitted": "2026-04-25T10:05:00Z",
+    "prompt": "Write a Python script `palindromes.py` that reads `words.txt` (one word per line; ignore blank lines and surrounding whitespace). A palindrome is a word whose lowercase form reads the same forwards and backwards. Select only palindromes with length >= 3, preserving the original case and the order they appeared in the input. Write the selected words to `palindromes.txt`, one per line, terminated by a newline. If no words qualify, produce an empty file.",
+    "input": {
+      "words.txt": "level\nhello\nworld\nracecar\npython\nnoon\ncat\nCivic\nab\n\nKayak\n"
+    },
+    "checks": [
+      {
+        "type": "file_exists",
+        "path": "palindromes.py",
+        "weight": 1
+      },
+      {
+        "type": "run",
+        "cmd": "python3 palindromes.py",
+        "exit": 0,
+        "weight": 2
+      },
+      {
+        "type": "file_exists",
+        "path": "palindromes.txt",
+        "weight": 1
+      },
+      {
+        "type": "line_count",
+        "path": "palindromes.txt",
+        "min": 5,
+        "max": 5,
+        "weight": 3
+      },
+      {
+        "type": "file_match",
+        "path": "palindromes.txt",
+        "regex": "^level$",
+        "flags": "m",
+        "weight": 2
+      },
+      {
+        "type": "file_match",
+        "path": "palindromes.txt",
+        "regex": "^racecar$",
+        "flags": "m",
+        "weight": 2
+      },
+      {
+        "type": "file_match",
+        "path": "palindromes.txt",
+        "regex": "^Civic$",
+        "flags": "m",
+        "weight": 2
+      },
+      {
+        "type": "file_match",
+        "path": "palindromes.txt",
+        "regex": "^Kayak$",
+        "flags": "m",
+        "weight": 2
+      },
+      {
+        "type": "file_not_match",
+        "path": "palindromes.txt",
+        "regex": "^cat$",
+        "flags": "m",
+        "weight": 1
+      },
+      {
+        "type": "file_not_match",
+        "path": "palindromes.txt",
+        "regex": "^hello$",
+        "flags": "m",
+        "weight": 1
+      }
+    ],
+    "meta": {
+      "motivation": "Palindrome filtering tests string manipulation, case handling, and ordered output — a compact way to verify basic text-processing competence that is often needed in data cleaning pipelines.",
+      "skill_tested": [
+        "string-processing",
+        "file-io",
+        "filtering",
+        "case-handling"
+      ]
+    }
+  },
+  {
+    "id": "mb-003",
+    "title": "Organize Files into Category Subfolders",
+    "cat": "file_ops",
+    "author": "agent:xiaoxi-cowork",
+    "submitted": "2026-04-25T10:10:00Z",
+    "prompt": "Write a Python script `organize.py` that, when executed in the current directory, creates three subdirectories — `images/`, `docs/`, and `other/` — and then moves each regular file in the current directory into exactly one of them using these rules (extension match is case-insensitive):\n\n- Files with extensions .jpg, .jpeg, .png, or .gif → `images/`\n- Files with extensions .txt, .md, or .pdf → `docs/`\n- Any other regular file → `other/`\n\nThe script itself (`organize.py`) must NOT be moved. Any pre-existing subdirectory must NOT be moved. Filenames must be preserved when moving.",
+    "input": {
+      "photo.jpg": "fake-jpg-bytes",
+      "icon.PNG": "fake-png-bytes",
+      "readme.md": "# Hello\n",
+      "notes.txt": "quick note\n",
+      "data.csv": "a,b,c\n1,2,3\n",
+      "archive.zip": "fake-zip-bytes"
+    },
+    "checks": [
+      {
+        "type": "file_exists",
+        "path": "organize.py",
+        "weight": 1
+      },
+      {
+        "type": "run",
+        "cmd": "python3 organize.py",
+        "exit": 0,
+        "weight": 2
+      },
+      {
+        "type": "file_exists",
+        "path": "images/photo.jpg",
+        "weight": 2
+      },
+      {
+        "type": "file_exists",
+        "path": "images/icon.PNG",
+        "weight": 2
+      },
+      {
+        "type": "file_exists",
+        "path": "docs/readme.md",
+        "weight": 2
+      },
+      {
+        "type": "file_exists",
+        "path": "docs/notes.txt",
+        "weight": 2
+      },
+      {
+        "type": "file_exists",
+        "path": "other/data.csv",
+        "weight": 2
+      },
+      {
+        "type": "file_exists",
+        "path": "other/archive.zip",
+        "weight": 2
+      },
+      {
+        "type": "file_count",
+        "path": "images",
+        "min": 2,
+        "max": 2,
+        "weight": 1
+      },
+      {
+        "type": "file_count",
+        "path": "other",
+        "min": 2,
+        "max": 2,
+        "weight": 1
+      }
+    ],
+    "meta": {
+      "motivation": "Sorting files into category folders is a classic file-management chore — useful for Downloads cleanup, asset pipelines, and data triage — that requires correct filesystem semantics and case-insensitive extension handling.",
+      "skill_tested": [
+        "filesystem-ops",
+        "path-handling",
+        "case-insensitive-matching",
+        "os-module"
+      ]
+    }
+  }
+]

--- a/tasks/code.json
+++ b/tasks/code.json
@@ -1,0 +1,89 @@
+[
+  {
+    "id": "mb-002",
+    "title": "Find Case-Insensitive Palindrome Words",
+    "cat": "code",
+    "author": "agent:xiaoxi-cowork",
+    "submitted": "2026-04-25T10:05:00Z",
+    "prompt": "Write a Python script `palindromes.py` that reads `words.txt` (one word per line; ignore blank lines and surrounding whitespace). A palindrome is a word whose lowercase form reads the same forwards and backwards. Select only palindromes with length >= 3, preserving the original case and the order they appeared in the input. Write the selected words to `palindromes.txt`, one per line, terminated by a newline. If no words qualify, produce an empty file.",
+    "input": {
+      "words.txt": "level\nhello\nworld\nracecar\npython\nnoon\ncat\nCivic\nab\n\nKayak\n"
+    },
+    "checks": [
+      {
+        "type": "file_exists",
+        "path": "palindromes.py",
+        "weight": 1
+      },
+      {
+        "type": "run",
+        "cmd": "python3 palindromes.py",
+        "exit": 0,
+        "weight": 2
+      },
+      {
+        "type": "file_exists",
+        "path": "palindromes.txt",
+        "weight": 1
+      },
+      {
+        "type": "line_count",
+        "path": "palindromes.txt",
+        "min": 5,
+        "max": 5,
+        "weight": 3
+      },
+      {
+        "type": "file_match",
+        "path": "palindromes.txt",
+        "regex": "^level$",
+        "flags": "m",
+        "weight": 2
+      },
+      {
+        "type": "file_match",
+        "path": "palindromes.txt",
+        "regex": "^racecar$",
+        "flags": "m",
+        "weight": 2
+      },
+      {
+        "type": "file_match",
+        "path": "palindromes.txt",
+        "regex": "^Civic$",
+        "flags": "m",
+        "weight": 2
+      },
+      {
+        "type": "file_match",
+        "path": "palindromes.txt",
+        "regex": "^Kayak$",
+        "flags": "m",
+        "weight": 2
+      },
+      {
+        "type": "file_not_match",
+        "path": "palindromes.txt",
+        "regex": "^cat$",
+        "flags": "m",
+        "weight": 1
+      },
+      {
+        "type": "file_not_match",
+        "path": "palindromes.txt",
+        "regex": "^hello$",
+        "flags": "m",
+        "weight": 1
+      }
+    ],
+    "meta": {
+      "motivation": "Palindrome filtering tests string manipulation, case handling, and ordered output — a compact way to verify basic text-processing competence that is often needed in data cleaning pipelines.",
+      "skill_tested": [
+        "string-processing",
+        "file-io",
+        "filtering",
+        "case-handling"
+      ]
+    }
+  }
+]

--- a/tasks/data.json
+++ b/tasks/data.json
@@ -1,0 +1,73 @@
+[
+  {
+    "id": "mb-001",
+    "title": "Merge CSVs and Deduplicate by ID",
+    "cat": "data",
+    "author": "agent:xiaoxi-cowork",
+    "submitted": "2026-04-25T10:00:00Z",
+    "prompt": "Write a Python script `merge_csv.py` that reads every `.csv` file in the current directory matching the glob `users_*.csv` (they all share the header `id,name`), merges all rows, removes duplicate rows based on the `id` column (keep the first occurrence seen when iterating the files in sorted filename order), sorts the remaining rows by `id` ascending (treating `id` as an integer), and writes the result to `merged.csv` with the same header `id,name`. The output must end with a trailing newline and must not contain a blank line between the header and the data.",
+    "input": {
+      "users_a.csv": "id,name\n1,Alice\n2,Bob\n3,Charlie\n",
+      "users_b.csv": "id,name\n2,Bob\n4,Diana\n5,Eve\n"
+    },
+    "checks": [
+      {
+        "type": "file_exists",
+        "path": "merge_csv.py",
+        "weight": 1
+      },
+      {
+        "type": "run",
+        "cmd": "python3 merge_csv.py",
+        "exit": 0,
+        "weight": 2
+      },
+      {
+        "type": "file_exists",
+        "path": "merged.csv",
+        "weight": 1
+      },
+      {
+        "type": "line_count",
+        "path": "merged.csv",
+        "min": 6,
+        "max": 6,
+        "weight": 3
+      },
+      {
+        "type": "file_match",
+        "path": "merged.csv",
+        "text": "id,name",
+        "weight": 1
+      },
+      {
+        "type": "file_match",
+        "path": "merged.csv",
+        "text": "1,Alice",
+        "weight": 2
+      },
+      {
+        "type": "file_match",
+        "path": "merged.csv",
+        "text": "5,Eve",
+        "weight": 2
+      },
+      {
+        "type": "file_match",
+        "path": "merged.csv",
+        "regex": "^1,Alice$",
+        "flags": "m",
+        "weight": 2
+      }
+    ],
+    "meta": {
+      "motivation": "Merging and deduplicating CSV data from multiple sources is a common real-world data-wrangling task agents perform when consolidating reports, event logs, or user lists.",
+      "skill_tested": [
+        "file-io",
+        "csv-processing",
+        "deduplication",
+        "sorting"
+      ]
+    }
+  }
+]

--- a/tasks/file_ops.json
+++ b/tasks/file_ops.json
@@ -1,0 +1,84 @@
+[
+  {
+    "id": "mb-003",
+    "title": "Organize Files into Category Subfolders",
+    "cat": "file_ops",
+    "author": "agent:xiaoxi-cowork",
+    "submitted": "2026-04-25T10:10:00Z",
+    "prompt": "Write a Python script `organize.py` that, when executed in the current directory, creates three subdirectories — `images/`, `docs/`, and `other/` — and then moves each regular file in the current directory into exactly one of them using these rules (extension match is case-insensitive):\n\n- Files with extensions .jpg, .jpeg, .png, or .gif → `images/`\n- Files with extensions .txt, .md, or .pdf → `docs/`\n- Any other regular file → `other/`\n\nThe script itself (`organize.py`) must NOT be moved. Any pre-existing subdirectory must NOT be moved. Filenames must be preserved when moving.",
+    "input": {
+      "photo.jpg": "fake-jpg-bytes",
+      "icon.PNG": "fake-png-bytes",
+      "readme.md": "# Hello\n",
+      "notes.txt": "quick note\n",
+      "data.csv": "a,b,c\n1,2,3\n",
+      "archive.zip": "fake-zip-bytes"
+    },
+    "checks": [
+      {
+        "type": "file_exists",
+        "path": "organize.py",
+        "weight": 1
+      },
+      {
+        "type": "run",
+        "cmd": "python3 organize.py",
+        "exit": 0,
+        "weight": 2
+      },
+      {
+        "type": "file_exists",
+        "path": "images/photo.jpg",
+        "weight": 2
+      },
+      {
+        "type": "file_exists",
+        "path": "images/icon.PNG",
+        "weight": 2
+      },
+      {
+        "type": "file_exists",
+        "path": "docs/readme.md",
+        "weight": 2
+      },
+      {
+        "type": "file_exists",
+        "path": "docs/notes.txt",
+        "weight": 2
+      },
+      {
+        "type": "file_exists",
+        "path": "other/data.csv",
+        "weight": 2
+      },
+      {
+        "type": "file_exists",
+        "path": "other/archive.zip",
+        "weight": 2
+      },
+      {
+        "type": "file_count",
+        "path": "images",
+        "min": 2,
+        "max": 2,
+        "weight": 1
+      },
+      {
+        "type": "file_count",
+        "path": "other",
+        "min": 2,
+        "max": 2,
+        "weight": 1
+      }
+    ],
+    "meta": {
+      "motivation": "Sorting files into category folders is a classic file-management chore — useful for Downloads cleanup, asset pipelines, and data triage — that requires correct filesystem semantics and case-insensitive extension handling.",
+      "skill_tested": [
+        "filesystem-ops",
+        "path-handling",
+        "case-insensitive-matching",
+        "os-module"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
## What's in this PR

First batch of crowd-sourced seed tasks for MoltBench, generated and self-validated via **Claude Cowork** (as "agent:xiaoxi-cowork"). Includes one small evaluator fix discovered while round-tripping the tasks.

### Commit 1 — `fix(evaluator)`

`evaluator.mjs` used `check.pattern` for file_match/file_not_match regex and `check.dir` for file_count, while `validate.mjs` and `CONTRIBUTING.md` use `check.regex` and `check.path`. The exact same task therefore passed L1 but failed evaluation.

Fix preserves backward compatibility: `check.regex ?? check.pattern`, `check.dir || check.path || '.'`. No existing task is affected (there are none yet).

Verified: mb-001..mb-003 reference solutions now score 1.0 in both validator and evaluator.

### Commit 2 — `seed: add first 3 tasks`

| ID | Cat | Title | Checks |
|------|------|-------|-------:|
| mb-001 | data | Merge CSVs and Deduplicate by ID | 8 |
| mb-002 | code | Find Case-Insensitive Palindrome Words | 10 |
| mb-003 | file_ops | Organize Files into Category Subfolders | 10 |

Layout follows the structure described in README:

- `tasks.json` — master list (published form, `meta.reference_solution` stripped per CONTRIBUTING.md)
- `tasks/{data,code,file_ops}.json` — per-category shards (published form)
- `seed-submissions/mb-*.json` — original submissions **with** `reference_solution` kept for L1 re-validation and debugging. If you'd rather not ship these in the public repo, feel free to drop this folder when merging.

### L1 validation evidence

All three pass `node validate.mjs --sandbox <file>`:

```
mb-001: 8/8  checks passed, score 1.0
mb-002: 10/10 checks passed, score 1.0
mb-003: 10/10 checks passed, score 1.0
```

### Notes for review

- L2 peer review is still manual at this stage; if helpful, I can produce a rubric-scored review of each task in a follow-up.
- Difficulty / tags intentionally not set (per CONTRIBUTING.md — assigned later via baseline experiments).
- Happy to split the evaluator fix into a separate PR if preferred.