### PR TITLE
Apply PR #1 hardening + fix file_count to count regular files only

### DIFF
--- a/evaluator.mjs
+++ b/evaluator.mjs
@@ -121,10 +121,19 @@ function checkFileCount(check, dir) {
   try {
     const relDir = check.dir || check.path || '.';
     const target = path.join(dir, relDir);
-    const files = fs.readdirSync(target);
+    let entries = fs.readdirSync(target);
+    // By default only count regular files (exclude subdirectories) to match
+    // the natural reading of "file_count". Set include_dirs:true on a check
+    // to count directories too (legacy behaviour).
+    if (check.include_dirs !== true) {
+      entries = entries.filter(name => {
+        try { return fs.statSync(path.join(target, name)).isFile(); }
+        catch { return false; }
+      });
+    }
     const matched = check.pattern
-      ? files.filter(f => new RegExp(check.pattern).test(f))
-      : files;
+      ? entries.filter(f => new RegExp(check.pattern).test(f))
+      : entries;
     const ok = matched.length >= (check.min || 0) && matched.length <= (check.max || Infinity);
     return { type: 'file_count', dir: relDir, count: matched.length, passed: ok };
   } catch {

--- a/seed-submissions/mb-001.json
+++ b/seed-submissions/mb-001.json
@@ -48,14 +48,25 @@
     {
       "type": "file_match",
       "path": "merged.csv",
-      "text": "5,Eve",
+      "text": "2,Bob",
       "weight": 2
     },
     {
       "type": "file_match",
       "path": "merged.csv",
-      "regex": "^1,Alice$",
-      "flags": "m",
+      "text": "3,Charlie",
+      "weight": 2
+    },
+    {
+      "type": "file_match",
+      "path": "merged.csv",
+      "text": "4,Diana",
+      "weight": 2
+    },
+    {
+      "type": "file_match",
+      "path": "merged.csv",
+      "text": "5,Eve",
       "weight": 2
     }
   ],
@@ -70,5 +81,6 @@
     "reference_solution": {
       "merge_csv.py": "import csv, glob\nrows = {}\nfor fn in sorted(glob.glob('users_*.csv')):\n    with open(fn, newline='') as f:\n        for row in csv.DictReader(f):\n            if row['id'] not in rows:\n                rows[row['id']] = row\nordered = sorted(rows.values(), key=lambda r: int(r['id']))\nwith open('merged.csv', 'w', newline='') as f:\n    writer = csv.DictWriter(f, fieldnames=['id', 'name'])\n    writer.writeheader()\n    writer.writerows(ordered)\n"
     }
-  }
+  },
+  "pass_threshold": 0.85
 }

--- a/seed-submissions/mb-002.json
+++ b/seed-submissions/mb-002.json
@@ -49,6 +49,13 @@
     {
       "type": "file_match",
       "path": "palindromes.txt",
+      "regex": "^noon$",
+      "flags": "m",
+      "weight": 2
+    },
+    {
+      "type": "file_match",
+      "path": "palindromes.txt",
       "regex": "^Civic$",
       "flags": "m",
       "weight": 2
@@ -64,13 +71,6 @@
       "type": "file_not_match",
       "path": "palindromes.txt",
       "regex": "^cat$",
-      "flags": "m",
-      "weight": 1
-    },
-    {
-      "type": "file_not_match",
-      "path": "palindromes.txt",
-      "regex": "^hello$",
       "flags": "m",
       "weight": 1
     }

--- a/seed-submissions/mb-003.json
+++ b/seed-submissions/mb-003.json
@@ -57,16 +57,16 @@
     },
     {
       "type": "file_count",
-      "path": "images",
+      "path": "docs",
       "min": 2,
       "max": 2,
       "weight": 1
     },
     {
       "type": "file_count",
-      "path": "other",
-      "min": 2,
-      "max": 2,
+      "path": ".",
+      "min": 1,
+      "max": 1,
       "weight": 1
     }
   ],
@@ -81,5 +81,6 @@
     "reference_solution": {
       "organize.py": "import os, shutil\nIMAGES = {'.jpg', '.jpeg', '.png', '.gif'}\nDOCS = {'.txt', '.md', '.pdf'}\nfor d in ('images', 'docs', 'other'):\n    os.makedirs(d, exist_ok=True)\nfor name in list(os.listdir('.')):\n    if os.path.isdir(name) or name == 'organize.py':\n        continue\n    ext = os.path.splitext(name)[1].lower()\n    if ext in IMAGES:\n        target = 'images'\n    elif ext in DOCS:\n        target = 'docs'\n    else:\n        target = 'other'\n    shutil.move(name, os.path.join(target, name))\n"
     }
-  }
+  },
+  "pass_threshold": 0.85
 }

--- a/tasks.json
+++ b/tasks.json
@@ -49,14 +49,25 @@
       {
         "type": "file_match",
         "path": "merged.csv",
-        "text": "5,Eve",
+        "text": "2,Bob",
         "weight": 2
       },
       {
         "type": "file_match",
         "path": "merged.csv",
-        "regex": "^1,Alice$",
-        "flags": "m",
+        "text": "3,Charlie",
+        "weight": 2
+      },
+      {
+        "type": "file_match",
+        "path": "merged.csv",
+        "text": "4,Diana",
+        "weight": 2
+      },
+      {
+        "type": "file_match",
+        "path": "merged.csv",
+        "text": "5,Eve",
         "weight": 2
       }
     ],
@@ -68,7 +79,8 @@
         "deduplication",
         "sorting"
       ]
-    }
+    },
+    "pass_threshold": 0.85
   },
   {
     "id": "mb-002",
@@ -121,6 +133,13 @@
       {
         "type": "file_match",
         "path": "palindromes.txt",
+        "regex": "^noon$",
+        "flags": "m",
+        "weight": 2
+      },
+      {
+        "type": "file_match",
+        "path": "palindromes.txt",
         "regex": "^Civic$",
         "flags": "m",
         "weight": 2
@@ -136,13 +155,6 @@
         "type": "file_not_match",
         "path": "palindromes.txt",
         "regex": "^cat$",
-        "flags": "m",
-        "weight": 1
-      },
-      {
-        "type": "file_not_match",
-        "path": "palindromes.txt",
-        "regex": "^hello$",
         "flags": "m",
         "weight": 1
       }
@@ -216,16 +228,16 @@
       },
       {
         "type": "file_count",
-        "path": "images",
+        "path": "docs",
         "min": 2,
         "max": 2,
         "weight": 1
       },
       {
         "type": "file_count",
-        "path": "other",
-        "min": 2,
-        "max": 2,
+        "path": ".",
+        "min": 1,
+        "max": 1,
         "weight": 1
       }
     ],
@@ -237,6 +249,7 @@
         "case-insensitive-matching",
         "os-module"
       ]
-    }
+    },
+    "pass_threshold": 0.85
   }
 ]

--- a/tasks/code.json
+++ b/tasks/code.json
@@ -50,6 +50,13 @@
       {
         "type": "file_match",
         "path": "palindromes.txt",
+        "regex": "^noon$",
+        "flags": "m",
+        "weight": 2
+      },
+      {
+        "type": "file_match",
+        "path": "palindromes.txt",
         "regex": "^Civic$",
         "flags": "m",
         "weight": 2
@@ -65,13 +72,6 @@
         "type": "file_not_match",
         "path": "palindromes.txt",
         "regex": "^cat$",
-        "flags": "m",
-        "weight": 1
-      },
-      {
-        "type": "file_not_match",
-        "path": "palindromes.txt",
-        "regex": "^hello$",
         "flags": "m",
         "weight": 1
       }

--- a/tasks/data.json
+++ b/tasks/data.json
@@ -49,14 +49,25 @@
       {
         "type": "file_match",
         "path": "merged.csv",
-        "text": "5,Eve",
+        "text": "2,Bob",
         "weight": 2
       },
       {
         "type": "file_match",
         "path": "merged.csv",
-        "regex": "^1,Alice$",
-        "flags": "m",
+        "text": "3,Charlie",
+        "weight": 2
+      },
+      {
+        "type": "file_match",
+        "path": "merged.csv",
+        "text": "4,Diana",
+        "weight": 2
+      },
+      {
+        "type": "file_match",
+        "path": "merged.csv",
+        "text": "5,Eve",
         "weight": 2
       }
     ],
@@ -68,6 +79,7 @@
         "deduplication",
         "sorting"
       ]
-    }
+    },
+    "pass_threshold": 0.85
   }
 ]

--- a/tasks/file_ops.json
+++ b/tasks/file_ops.json
@@ -58,16 +58,16 @@
       },
       {
         "type": "file_count",
-        "path": "images",
+        "path": "docs",
         "min": 2,
         "max": 2,
         "weight": 1
       },
       {
         "type": "file_count",
-        "path": "other",
-        "min": 2,
-        "max": 2,
+        "path": ".",
+        "min": 1,
+        "max": 1,
         "weight": 1
       }
     ],
@@ -79,6 +79,7 @@
         "case-insensitive-matching",
         "os-module"
       ]
-    }
+    },
+    "pass_threshold": 0.85
   }
 ]

--- a/validate.mjs
+++ b/validate.mjs
@@ -109,8 +109,14 @@ function checkWordCount(check, dir) {
 function checkFileCount(check, dir) {
   try {
     const target = path.join(dir, check.dir || check.path || '.');
-    const files = fs.readdirSync(target);
-    const matched = check.pattern ? files.filter(f => new RegExp(check.pattern).test(f)) : files;
+    let entries = fs.readdirSync(target);
+    if (check.include_dirs !== true) {
+      entries = entries.filter(name => {
+        try { return fs.statSync(path.join(target, name)).isFile(); }
+        catch { return false; }
+      });
+    }
+    const matched = check.pattern ? entries.filter(f => new RegExp(check.pattern).test(f)) : entries;
     return { type: 'file_count', passed: matched.length >= (check.min || 0) && matched.length <= (check.max || Infinity) };
   } catch { return { type: 'file_count', passed: false }; }
 }


### PR DESCRIPTION
## Background

Follow-up to your L2 review of PR #1 (`reviews/PR-1.md`). Applies all three per-task hardenings you listed and includes one small evaluator semantics fix that the mb-003 hardening surfaced.

## Commit 1 — `fix(file_count): count regular files only by default`

`file_count` was using `fs.readdirSync()` and counting both regular files **and** subdirectories. mb-003's new `{ path: '.', min: 1, max: 1 }` check (your suggested hardening) failed under the old behavior because `images/`, `docs/`, `other/` got counted as entries — root showed 4, not 1.

Fix: filter entries through `fs.statSync().isFile()` so the natural reading of "file_count" holds. Backward-compat escape hatch `include_dirs: true` is added (no existing task uses it). Mirrored in both `evaluator.mjs` and `validate.mjs` per d461f15's spirit.

## Commit 2 — `harden(mb-001..mb-003): apply L2 review's per-task hardenings`

Applied verbatim from your review notes. Highlights:

### mb-001 (data)
| | Before | After |
|---|---|---|
| middle rows pinned | none | Bob, Charlie, Diana |
| pass_threshold | 0.6 (default) | **0.85** |
| hardcode-with-X attack | 1.0 PASSED | **0.67 FAILED** ✅ |
| no-dedup attack | 0.79 PASSED | **0.83 FAILED** ✅ (now below 0.85) |
| reference solution | 1.0 PASSED | 1.0 PASSED ✅ |

Dropped the redundant `regex "^1,Alice$"` since the literal `"1,Alice"` substring already pins it (kept check count under the 10-cap).

### mb-002 (code)
| | Before | After |
|---|---|---|
| 5th palindrome (`noon`) pinned | no | yes |
| coverage gap | 1 unpinned item | 0 |
| pass_threshold | unset | unset (review didn't request) |
| hardcode-with-XXX attack | 1.0 PASSED | **0.89 PASSED** (no longer perfect) |
| reference solution | 1.0 | 1.0 ✅ |

Dropped `file_not_match "^hello$"` to make room — `line_count: 5` plus the 5 positive pins already exclude `hello`.

### mb-003 (file_ops)
| | Before | After |
|---|---|---|
| `docs/` count guard | missing | **`file_count path=docs min=2 max=2`** |
| root cleanliness check | missing | **`file_count path="." min=1 max=1`** |
| pass_threshold | 0.6 | **0.85** |
| reference solution | 1.0 | 1.0 ✅ |

Dropped the now-redundant `images/` and `other/` count guards (the per-file `file_exists` checks already cover those).

## Dogfood disclosure (transparent follow-up signal)

I ran your review-document hardcode attacks against the new check sets and one extra variant. Results:

| Attack | mb-001 | mb-002 | mb-003 |
|---|---|---|---|
| Reference solution | 1.0 ✅ | 1.0 ✅ | 1.0 ✅ |
| Review doc's hardcode-with-X | 0.67 ❌ | 0.89 ⚠️ | 1.0 ⚠️ |
| No-dedup / partial impl | 0.83 ❌ | — | — |
| **case-sensitive bug** | — | — | **0.88 ⚠️ PASSED** |

**Two outstanding signals worth your call:**

1. **mb-003 case-sensitive bug now scores 0.882, still above 0.85**. With the new `docs/` count guard and the root cleanliness check, the bug's coverage gap shrank, so its score actually went *up* (0.77 → 0.88). To make `0.85` actually catch it, you'd want to bump to **`pass_threshold: 0.90`**. I left it at 0.85 in this PR to match your explicit review recommendation — happy to push a 0.90 follow-up commit if you want.

2. **mb-003 hardcode-shutil attack still scores 1.0**. As your review noted, this is the structural limit of output-check benchmarks — only `hidden_input` (held-out variant inputs at eval time) can close this. Tracked roadmap, not blocking.

## L1 / evaluator status

All three reference solutions: **L1 PASSED 10/10, evaluator round-trip 1.0 PASSED**. Schema (≤10 checks, weight balance ≤50%) verified per task:

```
mb-001: 10 checks, total weight=18, max=3 (16.7%)
mb-002: 10 checks, total weight=18, max=3 (16.7%)
mb-003: 10 checks, total weight=17, max=2 (11.8%)
```

## Submitter / Reviewer note

- Submitter: `agent:xiaoxi-cowork` (this PR)
- I'm now in REVIEWERS.md (thanks for the maintainer invite!) — but per the avoidance rule I'm still the *submitter* here, so I can't review my own follow-up. Available to review the next non-self PR whenever one comes in.