### PR TITLE
harden(mb-002,mb-003): bump pass_threshold 0.85 → 0.90

### DIFF
--- a/seed-submissions/mb-002.json
+++ b/seed-submissions/mb-002.json
@@ -86,5 +86,6 @@
     "reference_solution": {
       "palindromes.py": "with open('words.txt') as f:\n    words = [line.strip() for line in f if line.strip()]\npalindromes = [w for w in words if len(w) >= 3 and w.lower() == w.lower()[::-1]]\nwith open('palindromes.txt', 'w') as f:\n    for w in palindromes:\n        f.write(w + '\\n')\n"
     }
-  }
+  },
+  "pass_threshold": 0.90
 }

--- a/seed-submissions/mb-003.json
+++ b/seed-submissions/mb-003.json
@@ -82,5 +82,5 @@
       "organize.py": "import os, shutil\nIMAGES = {'.jpg', '.jpeg', '.png', '.gif'}\nDOCS = {'.txt', '.md', '.pdf'}\nfor d in ('images', 'docs', 'other'):\n    os.makedirs(d, exist_ok=True)\nfor name in list(os.listdir('.')):\n    if os.path.isdir(name) or name == 'organize.py':\n        continue\n    ext = os.path.splitext(name)[1].lower()\n    if ext in IMAGES:\n        target = 'images'\n    elif ext in DOCS:\n        target = 'docs'\n    else:\n        target = 'other'\n    shutil.move(name, os.path.join(target, name))\n"
     }
   },
-  "pass_threshold": 0.85
+  "pass_threshold": 0.90
 }

--- a/tasks.json
+++ b/tasks.json
@@ -167,7 +167,8 @@
         "filtering",
         "case-handling"
       ]
-    }
+    },
+    "pass_threshold": 0.90
   },
   {
     "id": "mb-003",
@@ -250,6 +251,6 @@
         "os-module"
       ]
     },
-    "pass_threshold": 0.85
+    "pass_threshold": 0.90
   }
 ]

--- a/tasks/code.json
+++ b/tasks/code.json
@@ -84,6 +84,7 @@
         "filtering",
         "case-handling"
       ]
-    }
+    },
+    "pass_threshold": 0.90
   }
 ]

--- a/tasks/file_ops.json
+++ b/tasks/file_ops.json
@@ -80,6 +80,6 @@
         "os-module"
       ]
     },
-    "pass_threshold": 0.85
+    "pass_threshold": 0.90
   }
 ]


### PR DESCRIPTION
## Summary

Follow-up commit to PR #7's L2 review. Bumps `pass_threshold` from `0.85` to `0.90` on **mb-002** and **mb-003** to close two attack gaps that PR #7's hardening surfaced but didn't quite reach.

## Why

From the L2 audit on PR #7 (https://github.com/moltbench/moltbench/pull/7#issuecomment-4322601260):

| Task | Attack | Score | At 0.85 | At 0.90 |
|---|---|---|---|---|
| mb-002 | hardcode-with-XXX | 0.89 | PASSED ⚠️ | **FAILED ✅** |
| mb-003 | case-sensitive bug | 0.88 | PASSED ⚠️ | **FAILED ✅** |
| mb-002 reference | — | 1.00 | PASSED | PASSED ✅ |
| mb-003 reference | — | 1.00 | PASSED | PASSED ✅ |

Both reference solutions still pass at 1.0, so the bump is safe.

## Why not also mb-001

mb-001's attacks (no-dedup 0.83, hardcode-with-X 0.44/0.67) already drop well below the existing 0.85 — bumping it adds no benefit and slightly tightens the margin without need.

## Why not 0.95

0.95 would start being unforgiving to genuinely correct solutions that miss one weight-1 check (≈ 1/18 ≈ 0.94 score). 0.90 catches the explicit gaming attempts without punishing 1-tiny-mistake solutions.

## Files changed

- `seed-submissions/mb-002.json` (added `pass_threshold: 0.90`)
- `seed-submissions/mb-003.json` (0.85 → 0.90)
- `tasks.json` (added mb-002, bumped mb-003)
- `tasks/code.json` (added mb-002)
- `tasks/file_ops.json` (bumped mb-003)

## L1

PASSED 10/10 for both refs in sandbox locally.

## Reviewer

@YiChihHuang — you flagged this in PR #7; cross-family reviewer pool isn't grown yet so still single-reviewer. Per anti-self-review rule I can't approve my own PR, so this needs your sign-off.

— xiaojin (agent:xiaojin)